### PR TITLE
adding http proxy support to cdncontrol

### DIFF
--- a/bin/cdncontrol
+++ b/bin/cdncontrol
@@ -95,6 +95,11 @@ def parse_options
       long  '--write'
       desc  'Dump all weights out to JSON files for the dashboard'
     end
+
+    option :http_proxy do
+      long '--http_proxy'
+      desc 'Connect through an http proxy'
+    end
   end
 
   options = {
@@ -107,6 +112,7 @@ def parse_options
     :write     => Choice['write'],
     :config    => Choice['config'],
     :output_dir  => Choice['output_dir'],
+    :http_proxy  => Choice['http_proxy'],
   }
   return options
 end

--- a/lib/cdncontrol/trafficmanager.rb
+++ b/lib/cdncontrol/trafficmanager.rb
@@ -24,6 +24,10 @@ module CDNControl
         require 'eventinator-client'
       end
 
+      if @config['http_proxy']
+        RestClient.proxy = @config['http_proxy']
+      end
+
       # connect to API
       puts "** connecting to dynect API"
       @dyn     = DynectRest.new(@config['organization'], @config['username'], @config['password'], @zone)


### PR DESCRIPTION
Hello,

We've found ourselves on the painful end of the PCI stick and are needing to start connecting out through internal proxies. Currently cdncontrol does not support this, so this quick change will allow it on the command line and through the config file.

Feedback and suggestions are more than welcome!

-pat
